### PR TITLE
Eliminate warnings when running npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "Style guide generator ",
   "main": "index.js",
+  "repository": "https://github.com/Josh-Miller/stylizer",
   "scripts": {
     "test": "test stylizer"
   },
@@ -16,7 +17,6 @@
     "diveSync": "^0.3.0",
     "fs-extra": "^0.20.1",
     "glob": "^5.0.10",
-    "gulp": "^3.9.0",
     "gulp-build": "^0.5.3",
     "gulp-footer": "^1.0.5",
     "gulp-handlebars": "^4.0.0",
@@ -24,7 +24,6 @@
     "gulp-header": "^1.2.2",
     "gulp-template": "^3.0.0",
     "gulp-wrap": "^0.11.0",
-    "handlebars": "^3.0.3",
     "lodash": "^3.9.3",
     "path": "^0.11.14",
     "read-yaml": "^1.0.0",


### PR DESCRIPTION
I got the following warnings when installing for the first time.

```
npm WARN package.json stylizer@0.0.0 No repository field.
npm WARN package.json Dependency 'gulp' exists in both dependencies and devDependencies, using 'gulp@^3.9.0' from dependencies
npm WARN package.json Dependency 'handlebars' exists in both dependencies and devDependencies, using 'handlebars@^3.0.3' from dependencies
```
